### PR TITLE
Link Table of Contents in Footers

### DIFF
--- a/book/CHAPTER_01.md
+++ b/book/CHAPTER_01.md
@@ -108,4 +108,4 @@ The words came to rest like frost. Subtle, but colder than silence. Chronicler b
 
 ### ~ ~ ~
 
-[Prologue](Prologue.md) | [Home](../) | [Chapter 2](CHAPTER_02.md)
+[Prologue](Prologue.md) | [Table of Contents](../README.md#table-of-contents) | [Chapter 2](CHAPTER_02.md)


### PR DESCRIPTION
Link the "Table of Contents" in the chapter footers instead of the "Home" link. This will make for a better reading experience for people who are reading the book in the Github mobile app.