### PR TITLE
Link Table of Contents in Footers

### DIFF
--- a/book/Appendix.md
+++ b/book/Appendix.md
@@ -132,4 +132,4 @@ Present day chapters
 
 ### ~ ~ ~
 
-[Epilogue](Epilogue.md) | [Home](../) | [Notes](Notes.md)
+[Epilogue](Epilogue.md) | [Table of Contents](Table_of_Contents.md) | [Notes](Notes.md)

--- a/book/CHAPTER_01.md
+++ b/book/CHAPTER_01.md
@@ -108,4 +108,4 @@ The words came to rest like frost. Subtle, but colder than silence. Chronicler b
 
 ### ~ ~ ~
 
-[Prologue](Prologue.md) | [Table of Contents](../README.md#table-of-contents) | [Chapter 2](CHAPTER_02.md)
+[Prologue](Prologue.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 2](CHAPTER_02.md)

--- a/book/CHAPTER_02.md
+++ b/book/CHAPTER_02.md
@@ -76,4 +76,4 @@ The world rarely grants peace without a cost. And even then, the toll is never p
 
 ### ~ ~ ~
 
-[Chapter 1](CHAPTER_01.md) | [Home](../) | [Chapter 3](CHAPTER_03.md)
+[Chapter 1](CHAPTER_01.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 3](CHAPTER_03.md)

--- a/book/CHAPTER_03.md
+++ b/book/CHAPTER_03.md
@@ -284,4 +284,4 @@ Wil groaned. “Oh, this will end *so well.*”
 
 ### ~ ~ ~
 
-[Chapter 2](CHAPTER_02.md) | [Home](../) | [Chapter 4](CHAPTER_04.md)
+[Chapter 2](CHAPTER_02.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 4](CHAPTER_04.md)

--- a/book/CHAPTER_04.md
+++ b/book/CHAPTER_04.md
@@ -130,4 +130,4 @@ What I do know is that I spent many sleepless wondering if I could have found it
 
 ### ~ ~ ~
 
-[Chapter 3](CHAPTER_03.md) | [Home](../) | [Chapter 5](CHAPTER_05.md)
+[Chapter 3](CHAPTER_03.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 5](CHAPTER_05.md)

--- a/book/CHAPTER_05.md
+++ b/book/CHAPTER_05.md
@@ -78,4 +78,4 @@ I barely heard him. I was still caught in the moment before—held captive by th
 
 ### ~ ~ ~
 
-[Chapter 4](CHAPTER_04.md) | [Home](../) | [Chapter 6](CHAPTER_06.md)
+[Chapter 4](CHAPTER_04.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 6](CHAPTER_06.md)

--- a/book/CHAPTER_06.md
+++ b/book/CHAPTER_06.md
@@ -104,4 +104,4 @@ Her laughter echoed briefly before fading into the stillness. When at last her m
 
 ### ~ ~ ~
 
-[Chapter 5](CHAPTER_05.md) | [Home](../) | [Chapter 7](CHAPTER_07.md)
+[Chapter 5](CHAPTER_05.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 7](CHAPTER_07.md)

--- a/book/CHAPTER_07.md
+++ b/book/CHAPTER_07.md
@@ -62,4 +62,4 @@ I stood there, my lute still in my hands, the silence of the stones all the more
 
 ### ~ ~ ~
 
-[Chapter 6](CHAPTER_06.md) | [Home](../) | [Chapter 8](CHAPTER_08.md)
+[Chapter 6](CHAPTER_06.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 8](CHAPTER_08.md)

--- a/book/CHAPTER_08.md
+++ b/book/CHAPTER_08.md
@@ -106,4 +106,4 @@ One way or another, I would find a way inside.
 
 ### ~ ~ ~
 
-[Chapter 7](CHAPTER_07.md) | [Home](../) | [Chapter 9](CHAPTER_09.md)
+[Chapter 7](CHAPTER_07.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 9](CHAPTER_09.md)

--- a/book/CHAPTER_09.md
+++ b/book/CHAPTER_09.md
@@ -140,4 +140,4 @@ Devi stepped aside, and I walked in. Greed pressed me forward, and doubt trailed
 
 ### ~ ~ ~
 
-[Chapter 8](CHAPTER_08.md) | [Home](../) | [Chapter 10](CHAPTER_10.md)
+[Chapter 8](CHAPTER_08.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 10](CHAPTER_10.md)

--- a/book/CHAPTER_10.md
+++ b/book/CHAPTER_10.md
@@ -68,4 +68,4 @@ I slept for two days.
 
 ### ~ ~ ~
 
-[Chapter 9](CHAPTER_09.md) | [Home](../) | [Chapter 11](CHAPTER_11.md)
+[Chapter 9](CHAPTER_09.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 11](CHAPTER_11.md)

--- a/book/CHAPTER_11.md
+++ b/book/CHAPTER_11.md
@@ -72,4 +72,4 @@ Her eyes sharpened immediately. Her posture changed, leaning forward like a hawk
 
 ### ~ ~ ~
 
-[Chapter 10](CHAPTER_10.md) | [Home](../) | [Chapter 12](CHAPTER_12.md)
+[Chapter 10](CHAPTER_10.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 12](CHAPTER_12.md)

--- a/book/CHAPTER_12.md
+++ b/book/CHAPTER_12.md
@@ -110,4 +110,4 @@ I nodded, the weight of that accomplishment settling over me like a heavy cloak.
 
 ### ~ ~ ~
 
-[Chapter 11](CHAPTER_11.md) | [Home](../) | [Chapter 13](CHAPTER_13.md)
+[Chapter 11](CHAPTER_11.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 13](CHAPTER_13.md)

--- a/book/CHAPTER_13.md
+++ b/book/CHAPTER_13.md
@@ -108,4 +108,4 @@ And then, all at once, the blackness took me.
 
 ### ~ ~ ~
 
-[Chapter 12](CHAPTER_12.md) | [Home](../) | [Chapter 14](CHAPTER_14.md)
+[Chapter 12](CHAPTER_12.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 14](CHAPTER_14.md)

--- a/book/CHAPTER_14.md
+++ b/book/CHAPTER_14.md
@@ -352,4 +352,4 @@ The rush of dawn air left me dizzy, and I let it carry me to the edge of the wor
 
 ### ~ ~ ~
 
-[Chapter 13](CHAPTER_13.md) | [Home](../) | [Chapter 15](CHAPTER_15.md)
+[Chapter 13](CHAPTER_13.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 15](CHAPTER_15.md)

--- a/book/CHAPTER_15.md
+++ b/book/CHAPTER_15.md
@@ -94,4 +94,4 @@ One way or another, I’d follow that thread to the end—through cold, through 
 
 ### ~ ~ ~
 
-[Chapter 14](CHAPTER_14.md) | [Home](../) | [Chapter 16](CHAPTER_16.md)
+[Chapter 14](CHAPTER_14.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 16](CHAPTER_16.md)

--- a/book/CHAPTER_16.md
+++ b/book/CHAPTER_16.md
@@ -48,4 +48,4 @@ Kote nodded, but the moment to begin didn’t come right away. He rested his han
 
 ### ~ ~ ~
 
-[Chapter 15](CHAPTER_15.md) | [Home](../) | [Chapter 17](CHAPTER_17.md)
+[Chapter 15](CHAPTER_15.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 17](CHAPTER_17.md)

--- a/book/CHAPTER_17.md
+++ b/book/CHAPTER_17.md
@@ -108,4 +108,4 @@ We had crossed into the Fae.
 
 ### ~ ~ ~
 
-[Chapter 16](CHAPTER_16.md) | [Home](../) | [Chapter 18](CHAPTER_18.md)
+[Chapter 16](CHAPTER_16.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 18](CHAPTER_18.md)

--- a/book/CHAPTER_18.md
+++ b/book/CHAPTER_18.md
@@ -362,4 +362,4 @@ Within the Waystone, Bast looked over the table indignantly. “Who are you call
 
 ### ~ ~ ~
 
-[Chapter 17](CHAPTER_17.md) | [Home](../) | [Chapter 19](CHAPTER_19.md)
+[Chapter 17](CHAPTER_17.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 19](CHAPTER_19.md)

--- a/book/CHAPTER_19.md
+++ b/book/CHAPTER_19.md
@@ -378,4 +378,4 @@ But I was watching Fascino retreat into the dusk, his movements too smooth, his 
 
 ### ~ ~ ~
 
-[Chapter 18](CHAPTER_18.md) | [Home](../) | [Chapter 20](CHAPTER_20.md)
+[Chapter 18](CHAPTER_18.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 20](CHAPTER_20.md)

--- a/book/CHAPTER_20.md
+++ b/book/CHAPTER_20.md
@@ -392,4 +392,4 @@ Instead of a third attempt, I breathed deeply, willed the tension out of my body
 
 ### ~ ~ ~
 
-[Chapter 19](CHAPTER_19.md) | [Home](../) | [Chapter 21](CHAPTER_21.md)
+[Chapter 19](CHAPTER_19.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 21](CHAPTER_21.md)

--- a/book/CHAPTER_21.md
+++ b/book/CHAPTER_21.md
@@ -236,4 +236,4 @@ The courtyard faded behind me as I turned and walked away, pressing my hand agai
 
 ### ~ ~ ~
 
-[Chapter 20](CHAPTER_20.md) | [Home](../) | [Chapter 22](CHAPTER_22.md)
+[Chapter 20](CHAPTER_20.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 22](CHAPTER_22.md)

--- a/book/CHAPTER_22.md
+++ b/book/CHAPTER_22.md
@@ -72,4 +72,4 @@ He looked down at the polished wood beneath his hands. Ran his thumb across a gr
 
 ### ~ ~ ~
 
-[Chapter 21](CHAPTER_21.md) | [Home](../) | [Chapter 23](CHAPTER_23.md)
+[Chapter 21](CHAPTER_21.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 23](CHAPTER_23.md)

--- a/book/CHAPTER_23.md
+++ b/book/CHAPTER_23.md
@@ -452,4 +452,4 @@ A slow breath left Bast’s lips. He turned away from the street, glancing towar
 
 ### ~ ~ ~
 
-[Chapter 22](CHAPTER_22.md) | [Home](../) | [Chapter 24](CHAPTER_24.md)
+[Chapter 22](CHAPTER_22.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 24](CHAPTER_24.md)

--- a/book/CHAPTER_24.md
+++ b/book/CHAPTER_24.md
@@ -220,4 +220,4 @@ I measured our odds—not good. Not in this tight space. Not against four watche
 
 ### ~ ~ ~
 
-[Chapter 23](CHAPTER_23.md) | [Home](../) | [Chapter 25](CHAPTER_25.md)
+[Chapter 23](CHAPTER_23.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 25](CHAPTER_25.md)

--- a/book/CHAPTER_25.md
+++ b/book/CHAPTER_25.md
@@ -228,4 +228,4 @@ I laughed—a true laugh, the first in what felt like days—and let the title s
 
 ### ~ ~ ~
 
-[Chapter 24](CHAPTER_24.md) | [Home](../) | [Chapter 26](CHAPTER_26.md)
+[Chapter 24](CHAPTER_24.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 26](CHAPTER_26.md)

--- a/book/CHAPTER_26.md
+++ b/book/CHAPTER_26.md
@@ -256,4 +256,4 @@ And neither of us were ready for that.
 
 ### ~ ~ ~
 
-[Chapter 25](CHAPTER_25.md) | [Home](../) | [Chapter 27](CHAPTER_27.md)
+[Chapter 25](CHAPTER_25.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 27](CHAPTER_27.md)

--- a/book/CHAPTER_27.md
+++ b/book/CHAPTER_27.md
@@ -384,4 +384,4 @@ I forced a smile of my own, though we both pretended not to notice the sting of 
 
 ### ~ ~ ~
 
-[Chapter 26](CHAPTER_26.md) | [Home](../) | [Chapter 28](CHAPTER_28.md)
+[Chapter 26](CHAPTER_26.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 28](CHAPTER_28.md)

--- a/book/CHAPTER_28.md
+++ b/book/CHAPTER_28.md
@@ -124,4 +124,4 @@ If the Amyr wouldn’t act, *I would.*
 
 ### ~ ~ ~
 
-[Chapter 27](CHAPTER_27.md) | [Home](../) | [Chapter 29](CHAPTER_29.md)
+[Chapter 27](CHAPTER_27.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 29](CHAPTER_29.md)

--- a/book/CHAPTER_29.md
+++ b/book/CHAPTER_29.md
@@ -118,4 +118,4 @@ And I did.
 
 ### ~ ~ ~
 
-[Chapter 28](CHAPTER_28.md) | [Home](../) | [Chapter 30](CHAPTER_30.md)
+[Chapter 28](CHAPTER_28.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 30](CHAPTER_30.md)

--- a/book/CHAPTER_30.md
+++ b/book/CHAPTER_30.md
@@ -161,4 +161,4 @@ Denna nodded, though her eyes stayed fixed on the soldiers below, sharp with tho
 
 ### ~ ~ ~
 
-[Chapter 29](CHAPTER_29.md) | [Home](../) | [Chapter 31](CHAPTER_31.md)
+[Chapter 29](CHAPTER_29.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 31](CHAPTER_31.md)

--- a/book/CHAPTER_31.md
+++ b/book/CHAPTER_31.md
@@ -132,4 +132,4 @@ And I couldn’t answer her. Not yet.
 
 ### ~ ~ ~
 
-[Chapter 30](CHAPTER_30.md) | [Home](../) | [Chapter 32](CHAPTER_32.md)
+[Chapter 30](CHAPTER_30.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 32](CHAPTER_32.md)

--- a/book/CHAPTER_32.md
+++ b/book/CHAPTER_32.md
@@ -84,4 +84,4 @@ But as the screaming continued above us, I turned toward the Tower. “Not witho
 
 ### ~ ~ ~
 
-[Chapter 31](CHAPTER_31.md) | [Home](../) | [Chapter 33](CHAPTER_33.md)
+[Chapter 31](CHAPTER_31.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 33](CHAPTER_33.md)

--- a/book/CHAPTER_33.md
+++ b/book/CHAPTER_33.md
@@ -110,4 +110,4 @@ For a moment, hope flickered. Then I saw the mangonel.
 
 ### ~ ~ ~
 
-[Chapter 32](CHAPTER_32.md) | [Home](../) | [Chapter 34](CHAPTER_34.md)
+[Chapter 32](CHAPTER_32.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 34](CHAPTER_34.md)

--- a/book/CHAPTER_34.md
+++ b/book/CHAPTER_34.md
@@ -102,4 +102,4 @@ Instead, I turned toward the others preparing for the next assault, blood seepin
 
 ### ~ ~ ~
 
-[Chapter 33](CHAPTER_33.md) | [Home](../) | [Chapter 35](CHAPTER_35.md)
+[Chapter 33](CHAPTER_33.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 35](CHAPTER_35.md)

--- a/book/CHAPTER_35.md
+++ b/book/CHAPTER_35.md
@@ -90,4 +90,4 @@ And then the Wind was all that remained as I fell.
 
 ### ~ ~ ~
 
-[Chapter 34](CHAPTER_34.md) | [Home](../) | [Chapter 36](CHAPTER_36.md)
+[Chapter 34](CHAPTER_34.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 36](CHAPTER_36.md)

--- a/book/CHAPTER_36.md
+++ b/book/CHAPTER_36.md
@@ -66,4 +66,4 @@ He turned toward the hearth again, his voice distant now. “Their story deserve
 
 ### ~ ~ ~
 
-[Chapter 35](CHAPTER_35.md) | [Home](../) | [Chapter 37](CHAPTER_37.md)
+[Chapter 35](CHAPTER_35.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 37](CHAPTER_37.md)

--- a/book/CHAPTER_37.md
+++ b/book/CHAPTER_37.md
@@ -92,4 +92,4 @@ For the first time since the Tower, a flicker of resolve sparked within me. I wa
 
 ### ~ ~ ~
 
-[Chapter 36](CHAPTER_36.md) | [Home](../) | [Chapter 38](CHAPTER_38.md)
+[Chapter 36](CHAPTER_36.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 38](CHAPTER_38.md)

--- a/book/CHAPTER_38.md
+++ b/book/CHAPTER_38.md
@@ -90,4 +90,4 @@ The darkness reached for me.
 
 ### ~ ~ ~
 
-[Chapter 37](CHAPTER_37.md) | [Home](../) | [Chapter 39](CHAPTER_39.md)
+[Chapter 37](CHAPTER_37.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 39](CHAPTER_39.md)

--- a/book/CHAPTER_39.md
+++ b/book/CHAPTER_39.md
@@ -140,4 +140,4 @@ The blade sank deep, and Lanre collapsed, the bitter smile still gracing his fac
 
 ### ~ ~ ~
 
-[Chapter 38](CHAPTER_38.md) | [Home](../) | [Chapter 40](CHAPTER_40.md)
+[Chapter 38](CHAPTER_38.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 40](CHAPTER_40.md)

--- a/book/CHAPTER_40.md
+++ b/book/CHAPTER_40.md
@@ -96,4 +96,4 @@ And so, we fled into the night.
 
 ### ~ ~ ~
 
-[Chapter 39](CHAPTER_39.md) | [Home](../) | [Chapter 41](CHAPTER_41.md)
+[Chapter 39](CHAPTER_39.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 41](CHAPTER_41.md)

--- a/book/CHAPTER_41.md
+++ b/book/CHAPTER_41.md
@@ -70,4 +70,4 @@ Thin clouds shifted lazily above me, pale and distant—out of reach.
 
 ### ~ ~ ~
 
-[Chapter 40](CHAPTER_40.md) | [Home](../) | [Chapter 42](CHAPTER_42.md)
+[Chapter 40](CHAPTER_40.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 42](CHAPTER_42.md)

--- a/book/CHAPTER_42.md
+++ b/book/CHAPTER_42.md
@@ -80,4 +80,4 @@ Under the swaying trees, I held her as the fires died.
 
 ### ~ ~ ~
 
-[Chapter 41](CHAPTER_41.md) | [Home](../) | [Chapter 43](CHAPTER_43.md)
+[Chapter 41](CHAPTER_41.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 43](CHAPTER_43.md)

--- a/book/CHAPTER_43.md
+++ b/book/CHAPTER_43.md
@@ -36,4 +36,4 @@ Inside, the room was warm, but warmth was never enough.
 
 ### ~ ~ ~
 
-[Chapter 42](CHAPTER_42.md) | [Home](../) | [Chapter 44](CHAPTER_44.md)
+[Chapter 42](CHAPTER_42.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 44](CHAPTER_44.md)

--- a/book/CHAPTER_44.md
+++ b/book/CHAPTER_44.md
@@ -96,4 +96,4 @@ I clapped my good hand against his shoulder. “Well, for what it’s worth, I'm
 
 ### ~ ~ ~
 
-[Chapter 43](CHAPTER_43.md) | [Home](../) | [Chapter 45](CHAPTER_45.md)
+[Chapter 43](CHAPTER_43.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 45](CHAPTER_45.md)

--- a/book/CHAPTER_45.md
+++ b/book/CHAPTER_45.md
@@ -146,4 +146,4 @@ Auri smiled, faint and glowing.
 
 ### ~ ~ ~
 
-[Chapter 44](CHAPTER_44.md) | [Home](../) | [Chapter 46](CHAPTER_46.md)
+[Chapter 44](CHAPTER_44.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 46](CHAPTER_46.md)

--- a/book/CHAPTER_46.md
+++ b/book/CHAPTER_46.md
@@ -74,4 +74,4 @@ I sat alone after he left, staring at the crooked shelf Auri had made for me. I 
 
 ### ~ ~ ~
 
-[Chapter 45](CHAPTER_45.md) | [Home](../) | [Chapter 47](CHAPTER_47.md)
+[Chapter 45](CHAPTER_45.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 47](CHAPTER_47.md)

--- a/book/CHAPTER_47.md
+++ b/book/CHAPTER_47.md
@@ -130,4 +130,4 @@ So, I ran.
 
 ### ~ ~ ~
 
-[Chapter 46](CHAPTER_46.md) | [Home](../) | [Chapter 48](CHAPTER_48.md)
+[Chapter 46](CHAPTER_46.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 48](CHAPTER_48.md)

--- a/book/CHAPTER_48.md
+++ b/book/CHAPTER_48.md
@@ -214,4 +214,4 @@ Kvothe stood, his back straightening fully as he turned to face the shadow that 
 
 ### ~ ~ ~
 
-[Chapter 47](CHAPTER_47.md) | [Home](../) | [Chapter 49](CHAPTER_49.md)
+[Chapter 47](CHAPTER_47.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 49](CHAPTER_49.md)

--- a/book/CHAPTER_49.md
+++ b/book/CHAPTER_49.md
@@ -132,4 +132,4 @@ I stepped closer and, without a word, brought *Folly* down. The blade severed hi
 
 ### ~ ~ ~
 
-[Chapter 48](CHAPTER_48.md) | [Home](../) | [Chapter 50](CHAPTER_50.md)
+[Chapter 48](CHAPTER_48.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 50](CHAPTER_50.md)

--- a/book/CHAPTER_50.md
+++ b/book/CHAPTER_50.md
@@ -58,4 +58,4 @@ For a moment, the hovel seemed smaller, the air too thick, the space too tight. 
 
 ### ~ ~ ~
 
-[Chapter 49](CHAPTER_49.md) | [Home](../) | [Chapter 51](CHAPTER_51.md)
+[Chapter 49](CHAPTER_49.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 51](CHAPTER_51.md)

--- a/book/CHAPTER_51.md
+++ b/book/CHAPTER_51.md
@@ -44,4 +44,4 @@ The end.
 
 ### ~ ~ ~
 
-[Chapter 50](CHAPTER_50.md) | [Home](../) | [Epilogue](Epilogue.md)
+[Chapter 50](CHAPTER_50.md) | [Table of Contents](Table_of_Contents.md) | [Epilogue](Epilogue.md)

--- a/book/Cover_Page.md
+++ b/book/Cover_Page.md
@@ -2,4 +2,4 @@
 
 ### ~ ~ ~
 
-[Home](../) | [Title Page](Title_Page.md)
+[Table of Contents](Table_of_Contents.md) | [Title Page](Title_Page.md)

--- a/book/Epilogue.md
+++ b/book/Epilogue.md
@@ -38,4 +38,4 @@ Pehyn followed her mother home, her legs steady now, her shadow no longer dancin
 
 ### ~ ~ ~
 
-[Chapter 51](CHAPTER_51.md) | [Home](../) | [Appendix](Appendix.md)
+[Chapter 51](CHAPTER_51.md) | [Table of Contents](Table_of_Contents.md) | [Appendix](Appendix.md)

--- a/book/Forward.md
+++ b/book/Forward.md
@@ -14,4 +14,4 @@ That all said, please enjoy.
 
 ### ~ ~ ~
 
-[Legal Disclaimer](Legal_Disclaimer.md) | [Home](../) | [Prologue](Prologue.md)
+[Legal Disclaimer](Legal_Disclaimer.md) | [Table of Contents](Table_of_Contents.md) | [Prologue](Prologue.md)

--- a/book/Legal_Disclaimer.md
+++ b/book/Legal_Disclaimer.md
@@ -4,4 +4,4 @@ WE, THE AUTHORS of this fan fiction, can attest that we never sought permission,
 
 ### ~ ~ ~
 
-[Title Page](Title_Page.md) | [Home](../) | [Forward](Forward.md)
+[Title Page](Title_Page.md) | [Table of Contents](Table_of_Contents.md) | [Forward](Forward.md)

--- a/book/Notes.md
+++ b/book/Notes.md
@@ -140,4 +140,4 @@ Lyra was probably of the Ruarch (see Laniel young again), and sought Aleph's cou
 
 ### ~ ~ ~
 
-[Appendix](Appendix.md) | [Home](../)
+[Appendix](Appendix.md) | [Table of Contents](Table_of_Contents.md)

--- a/book/Prologue.md
+++ b/book/Prologue.md
@@ -16,4 +16,4 @@ And so the Waystone lay still. The silence waited with him.
 
 ### ~ ~ ~
 
-[Forward](Forward.md) | [Home](../) | [Chapter 1](CHAPTER_01.md)
+[Forward](Forward.md) | [Table of Contents](Table_of_Contents.md) | [Chapter 1](CHAPTER_01.md)

--- a/book/Table_of_Contents.md
+++ b/book/Table_of_Contents.md
@@ -1,5 +1,6 @@
 # TABLE OF CONTENTS
 
+* [*Cover*](Cover_Page.md)
 * [*Title Page*](titlepage.md)
 * [*Legal Disclaimer*](Legal_Disclaimer.md)
 * [*Forward*](Forward.md)

--- a/book/Title_Page.md
+++ b/book/Title_Page.md
@@ -8,4 +8,4 @@
 
 ### ~ ~ ~
 
-[Cover Page](Cover_Page.md) | [Home](../) | [Legal Disclaimer](Legal_Disclaimer.md)
+[Cover Page](Cover_Page.md) | [Table of Contents](Table_of_Contents.md) | [Legal Disclaimer](Legal_Disclaimer.md)


### PR DESCRIPTION
Link the "Table of Contents" in the chapter footers instead of the "Home" link. This will make for a better reading experience for people who are reading the book in the Github mobile app.