### PR TITLE
Chapter 16 Edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ That all said, please enjoy.
 * [CHAPTER 13](book/CHAPTER_13.md). I Will Not Be Held.
 * [CHAPTER 14](book/CHAPTER_14.md). Name in the Wall.
 * [CHAPTER 15](book/CHAPTER_15.md). Missing.
-* [CHAPTER 16](book/CHAPTER_16.md). Interlude. By Cover of Night.
+* [CHAPTER 16](book/CHAPTER_16.md). Interlude. Omens.
 * [CHAPTER 17](book/CHAPTER_17.md). Of Dancing Stones.
 * [CHAPTER 18](book/CHAPTER_18.md). Define Lost.
 * [CHAPTER 19](book/CHAPTER_19.md). Amber and Ivory.
@@ -130,7 +130,7 @@ That all said, please enjoy.
 * [CHAPTER 33](book/CHAPTER_33.md). The Tower.
 * [CHAPTER 34](book/CHAPTER_34.md). Command in the Chaos.
 * [CHAPTER 35](book/CHAPTER_35.md). The Price of Loyalty.
-* [CHAPTER 36](book/CHAPTER_36.md). Interlude. A Weight of Names.
+* [CHAPTER 36](book/CHAPTER_36.md). Interlude. Burdens.
 * [CHAPTER 37](book/CHAPTER_37.md). The Breath After the Fall.
 * [CHAPTER 38](book/CHAPTER_38.md). The Wolf and the Owl.
 * [CHAPTER 39](book/CHAPTER_39.md). The Weight of Shadows.

--- a/book/CHAPTER_16.md
+++ b/book/CHAPTER_16.md
@@ -2,50 +2,50 @@
 
 ## INTERLUDE.
 
-## BY COVER OF NIGHT.
+## OMENS.
 
 
-THE DECK BOARDS outside the Waystone creaked, groaning with the weight of age and weather, or perhaps with the secrets they held. Inside, the low hum of conversation fell abruptly silent, the way it does when people feel the eyes of the night pressing too heavily against the windows.  
+THE DECK BOARDS outside the Waystone creaked, groaning with the weight of age and weather, or perhaps with the secrets they held. Inside, the low hum of conversation fell abruptly silent, the way it does when an autumn chill presses against the windows, and the wind whips a tired shutter against its home.
 
-A moment passed, and the door swung inward with a weary reluctance. Old Cob stepped through, familiar and worn as an old coin, his boots scuffing against the hardwood as if even the floor itself resisted interrupting the quiet.  
+A moment passed, and the door swung inward with a weary reluctance. Old Cob stepped through, familiar and worn as an old coin, his boots scuffing against the hardwood as if even the floor itself resisted interrupting the quiet.
 
-“A pint o’ cider, Kote,” he grunted, stomping dust and dead grass from his boots before making his way to the bar. He slid into his usual place, the grooves of the stool seeming to fit him by now. “Helluva long day. Don’t s’pose there’s any o’ that pie left?”  
+“A pint o’ cider, Kote,” he grunted, stomping dust and dead grass from his boots before making his way to the bar. He slid into his usual place, the grooves of the stool seeming to fit him by now. “Helluva long morning. Don’t s’pose there’s any o’ that pie left?”
 
-“No pie, I’m afraid,” Kote said, his voice polite, apologetic. But his hands worked with the assurance of long habit as he pulled a tankard off the shelf, wiping its rim reflexively before pouring the cider. Each movement was efficient, unhurried. If the creak of the boards outside had put a sliver of tension into him, it didn’t show.  
+“No pie, I’m afraid,” Kote said, his voice polite, apologetic. But his hands worked with the assurance of long habit as he pulled a tankard off the shelf, wiping its rim reflexively before pouring the cider. Each movement was efficient, unhurried. If the creak of the boards outside had put a sliver of tension into him, it didn’t show.
 
-Cob clicked his tongue, disappointment quick and sharp. “Pity, that. Best thing to end a day, you know. Something warm and sweet.”  
+Cob clicked his tongue, disappointment quick and sharp. “Pity, that. Best thing to keep you going, you know. Something warm and sweet.”
 
-Kote slid the cider across the counter with a nod, and Cob took it with both hands, drinking half in one pull. He let out a satisfied sigh, setting the tankard down with a soft thunk against the wood. “Now, that’s good. Nothing like cider to settle the dust in your throat.”  
+Kote slid the cider across the counter with a nod, and Cob took it with both hands, drinking half in one pull. He let out a satisfied sigh, setting the tankard down with a soft thunk against the wood. “Now, that’s good. Nothing like cider to settle the dust in your throat.”
 
-He leaned against the bar, his face shifting into something more serious, though it stayed shaded by familiarity’s easy mask. “By the by, I had a talk with the Bentleys earlier. Seen ’em packing up all their things. Big wagon hitched out front, stuff tied down like they meant it for good and proper leavin’.”  
+He leaned against the bar, his face shifting into something more serious, though it stayed shaded by familiarity’s easy mask. “By the by, I had a talk with the Bentleys earlier. Seen ’em packing up all their things. Big wagon hitched out front, stuff tied down like they meant it for good and proper leavin’.”
 
-“Did they say why?” Kote asked, still polite, still calm. But the way he set the now-empty pitcher aside—soft, deliberate—felt like the fading echo of a dropped pin.  
+“Did they say why?” Kote asked, still polite, still calm. He set the now-empty pitcher aside softly and deliberately. The gesture felt like the fading echo of a dropped pin.
 
-Cob nodded, his lips pressing thin, as if chewing on something bitter. “Aye. Said they saw a man skulking in the woods behind their place last night. Or—not a man, exactly. Sarah said it didn’t walk right. Legs too long or too lean, and the arms hanging all too low, like a willow tree just about to touch water. Gave her the shivers summat fierce.”
+Cob nodded, his lips pressing thin, as if chewing on something bitter. “Aye. Say they saw a something lurkin’ in their backwoods last night. Not quite a man, exactly. Sarah say it didn’t walk right. Legs too long, or too lean. Arms hanging all too low. Gave her the shivers, summat fierce.”
 
-His eyes darted to the window, as if expecting to see the shadow of his words pressed against the glass. “Couldn’t talk her outta it. Said she knew what she saw and didn’t want to stay and see it again.”  
+His eyes darted to the window, as if expecting to see the shadow of his words pressed against the glass. “Couldn’t talk her outta it. Say she knew what she saw and didn’t want to stay and see it again.”
 
-Kote didn’t move except to stifle a yawn with the back of his hand. He set the bar rag down, folded neatly over his fingers. “That’s a bit of bad luck,” he said mildly.  
+Kote didn’t move except to stifle a yawn with the back of his hand. He set the bar rag down, folded neatly over his fingers. “That’s a bit of bad luck,” he said mildly.
 
-Cob snorted, finishing off the cider with a flick of his wrist. “Luck?” He set the tankard down and jabbed a thumb toward the door. “Luck ain’t got a whit to do with it. It’s all this blasted nonsense springin’ up. Shep gone, Carter bringin’ in that odd thing from the woods, soldiers n’ bandits thick as flies on the road. I tell ya, Kote, the Bentleys might have the right of it, runnin’ while they’ve got the legs for it.”  
+Cob snorted, finishing off the cider with a flick of his wrist. “Luck?” He set the tankard down and jabbed a thumb toward the door. “Luck ain’t got a whit to do with it. It’s all this blasted nonsense springin’ up. Shep gone, Carter bringin’ in that odd thing from the woods, soldiers n’ bandits thick as flies on the road. I tell ya, Kote, the Bentleys might have the right of it, runnin’ while they’ve got the legs for it.”
 
-He pushed away from the bar with a groan, his joints popping loud enough to carry in the quiet. “Anyway, I’d best be off. Things to tend to, as ever.” He gave Kote a short nod and turned toward the door, boots heavy against the floor like punctuation to his words.  
+He pushed away from the bar with a groan, his joints popping loud enough to carry in the quiet. “Anyway, I’d best be off. Things to tend to, as ever.” He gave Kote a short nod and turned toward the door, boots heavy against the floor like punctuation to his words.
 
-The door closed behind him with a finality that seemed almost rude and left behind a louder silence than before.  
+The door closed behind him with a finality that seemed almost rude and left behind a louder silence than before.
 
-### * * *  
+### * * *
 
-Kote remained behind the bar, poised in his stillness for just a moment longer. There was nothing unusual in what Cob had said—superstitious mutterings, the usual fears of things that slink under the moon. People had left town before. People had come back.  
+Kote remained behind the bar, poised in his stillness for just a moment longer. There was nothing unusual in what Cob had said. The superstitious mutterings reflected the usual fears of things that slink under the moon. People had left town before. People had come back.
 
 Still, he leaned slightly, listening until Cob’s footfalls were no longer audible on the deck boards outfront. Then he moved back to the table at the far end of the common room, where the Chronicler waited. The man’s quill hung above the page, its tip blotting a small dot of ink onto the margin.  
 
 “Where were we?” Kote asked, his voice lighter now, casual as a well-worn cloak.  
 
-The Chronicler didn’t answer immediately; he was too busy scanning the last few lines of what he’d written, his fingers hovering over the edges of the page. “You were on your way to Renere,” he said at last.  
+The Chronicler didn’t answer right away because he was too busy scanning the last few lines of what he had written. His fingers hovered over the edges of the page. After a moment, he finally spoke. “You were on your way to Renere,” he said.
 
-Kote nodded, but the moment to begin didn’t come right away. He rested his hand idly on the table, his fingers just brushing the edge of the wood. The fire’s light chased shadows down the wall, their shapes twisting and flickering in ways Kote didn’t much care for. He let himself glance at the door, just once, before reaching for the story again.  
+Kote nodded, but the moment to begin didn’t come right away. He rested his hand idly on the table, his fingers just brushing the edge of the wood. The fire’s light chased shadows down the wall, their shapes twisting and flickering in ways Kote didn’t much care for. He let himself glance at the door, just once, before reaching for the story again.
 
-“Yes,” Kote said softly. “Renere.”  
+“Yes,” Kote said softly. “Renere.”
 
 ### ~ ~ ~
 

--- a/book/CHAPTER_36.md
+++ b/book/CHAPTER_36.md
@@ -2,7 +2,7 @@
 
 ## INTERLUDE.
 
-## A WEIGHT OF NAMES.
+## BURDENS.
 
 
 KOTE STOOD BEHIND THE Waystone Inn's bar, wiping the same mug for the third time, though it gleamed clean under the amber flicker of the hearth. His movements were slow, deliberate, like a man trying to tether himself to the present. Outside, wind pressed against the shutters, a soft howling that always seemed to find its way into this quiet corner of the world.  

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 <h1><big>T</big>HE <big>D</big>OORS OF <big>S</big>TONE <big>S</big>PECULATIVE <big>M</big>USINGS</h1>
 <h2>THE KINGKILLER CHRONICLE DAY THREE</h2>
 <h3>NOT PATRICK ROTHFUSS</h3>
-<h3>VERSION 3.05.19</h3>
+<h3>VERSION 3.05.20</h3>
 <hr />
 <a name="Legal_Disclaimer">
 <h1><big>L</big>EGAL <big>D</big>ISCLAIMER.</h1>
@@ -92,7 +92,7 @@
 <li><a href="#CHAPTER_13">CHAPTER 13</a>. I Will Not Be Held.</li>
 <li><a href="#CHAPTER_14">CHAPTER 14</a>. Name in the Wall.</li>
 <li><a href="#CHAPTER_15">CHAPTER 15</a>. Missing.</li>
-<li><a href="#CHAPTER_16">CHAPTER 16</a>. Interlude. By Cover of Night.</li>
+<li><a href="#CHAPTER_16">CHAPTER 16</a>. Interlude. Omens.</li>
 <li><a href="#CHAPTER_17">CHAPTER 17</a>. Of Dancing Stones.</li>
 <li><a href="#CHAPTER_18">CHAPTER 18</a>. Define Lost.</li>
 <li><a href="#CHAPTER_19">CHAPTER 19</a>. Amber and Ivory.</li>
@@ -112,7 +112,7 @@
 <li><a href="#CHAPTER_33">CHAPTER 33</a>. The Tower.</li>
 <li><a href="#CHAPTER_34">CHAPTER 34</a>. Command in the Chaos.</li>
 <li><a href="#CHAPTER_35">CHAPTER 35</a>. The Price of Loyalty.</li>
-<li><a href="#CHAPTER_36">CHAPTER 36</a>. Interlude. A Weight of Names.</li>
+<li><a href="#CHAPTER_36">CHAPTER 36</a>. Interlude. Burdens.</li>
 <li><a href="#CHAPTER_37">CHAPTER 37</a>. The Breath After the Fall.</li>
 <li><a href="#CHAPTER_38">CHAPTER 38</a>. The Wolf and the Owl.</li>
 <li><a href="#CHAPTER_39">CHAPTER 39</a>. The Weight of Shadows.</li>
@@ -1136,7 +1136,6 @@
 <p>I sank into the nearest seat, my legs trembling as though finally being able to shed the weight of the world. Sim remained standing, hands fidgeting nervously and his face tight with worry. But he didn&rsquo;t speak. It was his patience that undid me.</p>
 <p>&ldquo;I made a mess, Sim.&rdquo; My voice was raw, the words closer to a confession than a greeting. &ldquo;I&rsquo;ve done things.&rdquo; I tried to say more, but the words tangled in my throat. I could not force them out. I could not meet his eyes. For a while, there was only the silence between us.</p>
 <p>I looked up only when I could bear it no longer. Then I began to speak, because sometimes the only way out is forward, and all that remains is the telling.</p>
-<p>I told him everything.</p>
 <h3>* * *</h3>
 <p>I told him about Devi. How it began with a favor. A spice of life, as she called it. The warnings I let slip past. The mistakes that followed, and how everything unraveled. I told him how Lorren&rsquo;s strength wavered. How it cracked, then crumbled, right there before my eyes. I told him about the Duplicator. How I used it to steal from the Archives. How I hunted secrets that should have stayed buried.</p>
 <p>I told him how Haven had swallowed me whole, how Elodin had left me with nothing but riddles and warnings. And when the words grew harder to speak, with memories of Auri fragile and luminous in my mind's eye, I told him about her too. I told him about how Auri vanished but that I didn't know how or why. And how the pale ghosts I had conjured murmured reminders of my failure to protect her at every turn. I didn&rsquo;t deserve his listening ear, yet Sim stood there across from me, silent but resolute, drinking in every fractured thing I had to say.</p>
@@ -1174,28 +1173,28 @@
 <a name="CHAPTER_16">
 <h1><big>C</big>HAPTER 16.</h1>
 <h2>INTERLUDE.</h2>
-<h2>BY COVER OF NIGHT.</h2>
-<p><big>T</big>HE DECK BOARDS outside the Waystone creaked, groaning with the weight of age and weather, or perhaps with the secrets they held. Inside, the low hum of conversation fell abruptly silent, the way it does when people feel the eyes of the night pressing too heavily against the windows.  </p>
-<p>A moment passed, and the door swung inward with a weary reluctance. Old Cob stepped through, familiar and worn as an old coin, his boots scuffing against the hardwood as if even the floor itself resisted interrupting the quiet.  </p>
-<p>&ldquo;A pint o&rsquo; cider, Kote,&rdquo; he grunted, stomping dust and dead grass from his boots before making his way to the bar. He slid into his usual place, the grooves of the stool seeming to fit him by now. &ldquo;Helluva long day. Don&rsquo;t s&rsquo;pose there&rsquo;s any o&rsquo; that pie left?&rdquo;  </p>
-<p>&ldquo;No pie, I&rsquo;m afraid,&rdquo; Kote said, his voice polite, apologetic. But his hands worked with the assurance of long habit as he pulled a tankard off the shelf, wiping its rim reflexively before pouring the cider. Each movement was efficient, unhurried. If the creak of the boards outside had put a sliver of tension into him, it didn&rsquo;t show.  </p>
-<p>Cob clicked his tongue, disappointment quick and sharp. &ldquo;Pity, that. Best thing to end a day, you know. Something warm and sweet.&rdquo;  </p>
-<p>Kote slid the cider across the counter with a nod, and Cob took it with both hands, drinking half in one pull. He let out a satisfied sigh, setting the tankard down with a soft thunk against the wood. &ldquo;Now, that&rsquo;s good. Nothing like cider to settle the dust in your throat.&rdquo;  </p>
-<p>He leaned against the bar, his face shifting into something more serious, though it stayed shaded by familiarity&rsquo;s easy mask. &ldquo;By the by, I had a talk with the Bentleys earlier. Seen &rsquo;em packing up all their things. Big wagon hitched out front, stuff tied down like they meant it for good and proper leavin&rsquo;.&rdquo;  </p>
-<p>&ldquo;Did they say why?&rdquo; Kote asked, still polite, still calm. But the way he set the now-empty pitcher aside&mdash;soft, deliberate&mdash;felt like the fading echo of a dropped pin.  </p>
-<p>Cob nodded, his lips pressing thin, as if chewing on something bitter. &ldquo;Aye. Said they saw a man skulking in the woods behind their place last night. Or&mdash;not a man, exactly. Sarah said it didn&rsquo;t walk right. Legs too long or too lean, and the arms hanging all too low, like a willow tree just about to touch water. Gave her the shivers summat fierce.&rdquo;</p>
-<p>His eyes darted to the window, as if expecting to see the shadow of his words pressed against the glass. &ldquo;Couldn&rsquo;t talk her outta it. Said she knew what she saw and didn&rsquo;t want to stay and see it again.&rdquo;  </p>
-<p>Kote didn&rsquo;t move except to stifle a yawn with the back of his hand. He set the bar rag down, folded neatly over his fingers. &ldquo;That&rsquo;s a bit of bad luck,&rdquo; he said mildly.  </p>
-<p>Cob snorted, finishing off the cider with a flick of his wrist. &ldquo;Luck?&rdquo; He set the tankard down and jabbed a thumb toward the door. &ldquo;Luck ain&rsquo;t got a whit to do with it. It&rsquo;s all this blasted nonsense springin&rsquo; up. Shep gone, Carter bringin&rsquo; in that odd thing from the woods, soldiers n&rsquo; bandits thick as flies on the road. I tell ya, Kote, the Bentleys might have the right of it, runnin&rsquo; while they&rsquo;ve got the legs for it.&rdquo;  </p>
-<p>He pushed away from the bar with a groan, his joints popping loud enough to carry in the quiet. &ldquo;Anyway, I&rsquo;d best be off. Things to tend to, as ever.&rdquo; He gave Kote a short nod and turned toward the door, boots heavy against the floor like punctuation to his words.  </p>
-<p>The door closed behind him with a finality that seemed almost rude and left behind a louder silence than before.  </p>
+<h2>OMENS.</h2>
+<p><big>T</big>HE DECK BOARDS outside the Waystone creaked, groaning with the weight of age and weather, or perhaps with the secrets they held. Inside, the low hum of conversation fell abruptly silent, the way it does when an autumn chill presses against the windows, and the wind whips a tired shutter against its home.</p>
+<p>A moment passed, and the door swung inward with a weary reluctance. Old Cob stepped through, familiar and worn as an old coin, his boots scuffing against the hardwood as if even the floor itself resisted interrupting the quiet.</p>
+<p>&ldquo;A pint o&rsquo; cider, Kote,&rdquo; he grunted, stomping dust and dead grass from his boots before making his way to the bar. He slid into his usual place, the grooves of the stool seeming to fit him by now. &ldquo;Helluva long morning. Don&rsquo;t s&rsquo;pose there&rsquo;s any o&rsquo; that pie left?&rdquo;</p>
+<p>&ldquo;No pie, I&rsquo;m afraid,&rdquo; Kote said, his voice polite, apologetic. But his hands worked with the assurance of long habit as he pulled a tankard off the shelf, wiping its rim reflexively before pouring the cider. Each movement was efficient, unhurried. If the creak of the boards outside had put a sliver of tension into him, it didn&rsquo;t show.</p>
+<p>Cob clicked his tongue, disappointment quick and sharp. &ldquo;Pity, that. Best thing to keep you going, you know. Something warm and sweet.&rdquo;</p>
+<p>Kote slid the cider across the counter with a nod, and Cob took it with both hands, drinking half in one pull. He let out a satisfied sigh, setting the tankard down with a soft thunk against the wood. &ldquo;Now, that&rsquo;s good. Nothing like cider to settle the dust in your throat.&rdquo;</p>
+<p>He leaned against the bar, his face shifting into something more serious, though it stayed shaded by familiarity&rsquo;s easy mask. &ldquo;By the by, I had a talk with the Bentleys earlier. Seen &rsquo;em packing up all their things. Big wagon hitched out front, stuff tied down like they meant it for good and proper leavin&rsquo;.&rdquo;</p>
+<p>&ldquo;Did they say why?&rdquo; Kote asked, still polite, still calm. He set the now-empty pitcher aside softly and deliberately. The gesture felt like the fading echo of a dropped pin.</p>
+<p>Cob nodded, his lips pressing thin, as if chewing on something bitter. &ldquo;Aye. Say they saw a something lurkin&rsquo; in their backwoods last night. Not quite a man, exactly. Sarah say it didn&rsquo;t walk right. Legs too long, or too lean. Arms hanging all too low. Gave her the shivers, summat fierce.&rdquo;</p>
+<p>His eyes darted to the window, as if expecting to see the shadow of his words pressed against the glass. &ldquo;Couldn&rsquo;t talk her outta it. Say she knew what she saw and didn&rsquo;t want to stay and see it again.&rdquo;</p>
+<p>Kote didn&rsquo;t move except to stifle a yawn with the back of his hand. He set the bar rag down, folded neatly over his fingers. &ldquo;That&rsquo;s a bit of bad luck,&rdquo; he said mildly.</p>
+<p>Cob snorted, finishing off the cider with a flick of his wrist. &ldquo;Luck?&rdquo; He set the tankard down and jabbed a thumb toward the door. &ldquo;Luck ain&rsquo;t got a whit to do with it. It&rsquo;s all this blasted nonsense springin&rsquo; up. Shep gone, Carter bringin&rsquo; in that odd thing from the woods, soldiers n&rsquo; bandits thick as flies on the road. I tell ya, Kote, the Bentleys might have the right of it, runnin&rsquo; while they&rsquo;ve got the legs for it.&rdquo;</p>
+<p>He pushed away from the bar with a groan, his joints popping loud enough to carry in the quiet. &ldquo;Anyway, I&rsquo;d best be off. Things to tend to, as ever.&rdquo; He gave Kote a short nod and turned toward the door, boots heavy against the floor like punctuation to his words.</p>
+<p>The door closed behind him with a finality that seemed almost rude and left behind a louder silence than before.</p>
 <h3>* * *</h3>
-<p>Kote remained behind the bar, poised in his stillness for just a moment longer. There was nothing unusual in what Cob had said&mdash;superstitious mutterings, the usual fears of things that slink under the moon. People had left town before. People had come back.  </p>
+<p>Kote remained behind the bar, poised in his stillness for just a moment longer. There was nothing unusual in what Cob had said. The superstitious mutterings reflected the usual fears of things that slink under the moon. People had left town before. People had come back.</p>
 <p>Still, he leaned slightly, listening until Cob&rsquo;s footfalls were no longer audible on the deck boards outfront. Then he moved back to the table at the far end of the common room, where the Chronicler waited. The man&rsquo;s quill hung above the page, its tip blotting a small dot of ink onto the margin.  </p>
 <p>&ldquo;Where were we?&rdquo; Kote asked, his voice lighter now, casual as a well-worn cloak.  </p>
-<p>The Chronicler didn&rsquo;t answer immediately; he was too busy scanning the last few lines of what he&rsquo;d written, his fingers hovering over the edges of the page. &ldquo;You were on your way to Renere,&rdquo; he said at last.  </p>
-<p>Kote nodded, but the moment to begin didn&rsquo;t come right away. He rested his hand idly on the table, his fingers just brushing the edge of the wood. The fire&rsquo;s light chased shadows down the wall, their shapes twisting and flickering in ways Kote didn&rsquo;t much care for. He let himself glance at the door, just once, before reaching for the story again.  </p>
-<p>&ldquo;Yes,&rdquo; Kote said softly. &ldquo;Renere.&rdquo;  </p>
+<p>The Chronicler didn&rsquo;t answer right away because he was too busy scanning the last few lines of what he had written. His fingers hovered over the edges of the page. After a moment, he finally spoke. &ldquo;You were on your way to Renere,&rdquo; he said.</p>
+<p>Kote nodded, but the moment to begin didn&rsquo;t come right away. He rested his hand idly on the table, his fingers just brushing the edge of the wood. The fire&rsquo;s light chased shadows down the wall, their shapes twisting and flickering in ways Kote didn&rsquo;t much care for. He let himself glance at the door, just once, before reaching for the story again.</p>
+<p>&ldquo;Yes,&rdquo; Kote said softly. &ldquo;Renere.&rdquo;</p>
 <hr />
 <a name="CHAPTER_17">
 <h1><big>C</big>HAPTER 17.</h1>
@@ -3243,7 +3242,7 @@
 <a name="CHAPTER_36">
 <h1><big>C</big>HAPTER 36.</h1>
 <h2>INTERLUDE.</h2>
-<h2>A WEIGHT OF NAMES.</h2>
+<h2>BURDENS.</h2>
 <p><big>K</big>OTE STOOD BEHIND THE Waystone Inn's bar, wiping the same mug for the third time, though it gleamed clean under the amber flicker of the hearth. His movements were slow, deliberate, like a man trying to tether himself to the present. Outside, wind pressed against the shutters, a soft howling that always seemed to find its way into this quiet corner of the world.  </p>
 <p>&ldquo;You&rsquo;ve stopped, you know,&rdquo; Kote said suddenly, his voice low and flat.  </p>
 <p>The scratch of the Chronicler&rsquo;s quill ceased on the parchment. Kote didn&rsquo;t look up, his hands still tracing the rim of the mug. &ldquo;Your pen. It&rsquo;s silent. Why?&rdquo;  </p>


### PR DESCRIPTION
Chapter 16 edits. Also, rename chapter 36 so that all interlude chapters have one-word names for consistency (and for making table of content pages format better).