### PR TITLE
Fix Chrome SHortcut Name

### DIFF
--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,5 +1,5 @@
 {
-    "name": "The Kingkiller Chronicle Day Three",
+    "name": "Kingkiller: Day 3",
     "short_name": "Kingkiller: Day 3",
     "icons": [
         {


### PR DESCRIPTION
I suspect that Android Chrome uses the site.manifest's name as the suggested homescreen name instead of using the website's title. Seems an odd choice, but lets change this to make it consistent.