### PR TITLE
Website Title Capitalizations

### DIFF
--- a/index.html
+++ b/index.html
@@ -396,21 +396,23 @@ function display_palette() {
         <div class="book_cover_top_padding"></div>
         <h1 class="book_cover_title">
             <span class="definate_article word">
-                The
+                THE
             </span>
             <span class="emphasis word">
-                Price
+                PRICE
             </span>
             <span class="minor_word word">
-                of
+                OF
             </span>
-            <span class="word">Remembering</span>
+            <span class="word">
+                REMEMBERING
+            </span>
         </h1>
         <div class="book_cover_top">
             <h2 class="book_cover_series">
-                <span class="definite_article">The</span>
-                <span class="nowrap">Kingkiller</span>
-                <span class="nowrap">Chronicle</span>
+                <span class="definite_article">THE</span>
+                <span class="nowrap">KINGKILLER</span>
+                <span class="nowrap">CHRONICLE</span>
             </h2>
             <h3 class="book_cover_day">
                Day Three
@@ -426,9 +428,9 @@ function display_palette() {
             </div>
             
             <h3 class="book_cover_attribution">
-                <span class="nowrap">Not</span>
-                <span class="nowrap">Patrick</span>
-                <span class="nowrap">Rothfuss</span>
+                <span class="nowrap">NOT</span>
+                <span class="nowrap">PATRICK</span>
+                <span class="nowrap">ROTHFUSS</span>
             </h3>
 
             <h4 class="book_cover_version nowrap">

--- a/publish.py
+++ b/publish.py
@@ -330,21 +330,23 @@ function display_palette() {
         <div class="book_cover_top_padding"></div>
         <h1 class="book_cover_title">
             <span class="definate_article word">
-                The
+                THE
             </span>
             <span class="emphasis word">
-                Price
+                PRICE
             </span>
             <span class="minor_word word">
-                of
+                OF
             </span>
-            <span class="word">Remembering</span>
+            <span class="word">
+                REMEMBERING
+            </span>
         </h1>
         <div class="book_cover_top">
             <h2 class="book_cover_series">
-                <span class="definite_article">The</span>
-                <span class="nowrap">Kingkiller</span>
-                <span class="nowrap">Chronicle</span>
+                <span class="definite_article">THE</span>
+                <span class="nowrap">KINGKILLER</span>
+                <span class="nowrap">CHRONICLE</span>
             </h2>
             <h3 class="book_cover_day">
                Day Three
@@ -360,9 +362,9 @@ function display_palette() {
             </div>
             
             <h3 class="book_cover_attribution">
-                <span class="nowrap">Not</span>
-                <span class="nowrap">Patrick</span>
-                <span class="nowrap">Rothfuss</span>
+                <span class="nowrap">NOT</span>
+                <span class="nowrap">PATRICK</span>
+                <span class="nowrap">ROTHFUSS</span>
             </h3>
 
             <h4 class="book_cover_version nowrap">


### PR DESCRIPTION
Adjust the website title's capitalizations to mimic the book's. E.G> Title pages should be as similar as pratical with CSS styling removed.