### PR TITLE
Reorganize Scenes

### DIFF
--- a/book/CHAPTER_05.md
+++ b/book/CHAPTER_05.md
@@ -39,42 +39,6 @@ Did Elodin know I’d had a hand in Hemme’s downfall? Had Kilvin woven togethe
 
 Elodin stayed a moment longer, murmuring something that felt more like a prayer than a comment. Then he turned and walked away, leaving me there with my thoughts and the weighted silence of the burial ground.  
 
-### * * *
-
-That night, Elodin’s Naming class was the opposite of the graveyard. Where the grave had been still, the class crackled with restless energy. Firelight from the torches danced across the stone walls, throwing shadows that writhed like living things.
-
-“Kvothe.” Elodin’s voice cut through the air, snapping my name like a bowstring. “To the center.”
-
-I hesitated, but only for a heartbeat. Every eye in the room traced my movements as I stepped forward. I stood in the circle of space Elodin had carved out for moments like this, beneath the heavy gaze of ancient stonework and brighter, watchful eyes.
-
-Elodin paced slow circles around me, his movement oddly graceful, like a bird inspecting its prey after deciding it wasn’t, in fact, dead. “Tell me,” he said quietly. “What do you see in a Name?”
-
-His tone was too calm, too deliberate, and I braced myself. “I see truth,” I replied, my voice measured, even.
-
-Elodin stopped pacing. The faintest smile curved along his lips. “Clever. And true enough. But truth is not simple. It is not clean.” He began to move again, circling me steadily. “Truth is layered, Kvothe. A fragile thread wrapped in lies, in doubt, in sharp things eager to snap under tension.”
-
-I opened my mouth to respond, but Elodin wasn’t waiting.
-
-“A Name,” he said, “is more than truth. It is balance. It is connection. It is weight. It is the thing beneath all things."
-
-He paused then, looking straight at me, eyes bright and sharp. “If you pull too hard on one thread,” he said. He gestured, and a breath of wind moved through the room. It came light as a whisper, brushing against my cheek.
-
-“Everything comes undone."
-
-The air thickened. I could feel it winding tighter around me, impossibly heavy.
-
-Elodin leaned closer, his voice soft as silk. “Say it.”
-
-The Name hovered on the edge of sense, spinning just beyond my reach. And then, like plucking a string I couldn’t see, it rang through me. Not as sound exactly, but as a trembling resonance that pulled through my chest and fingers. The wind moved, shifting in perfect harmony with the name I didn’t so much call as breathe. A melody hidden within silence, waiting to be played.
-
-For a moment, it lingered at my side, light as breath, alive with motion. Then, thin as glass, it formed a ring around my finger before dissolving.
-
-The room fell still. Papers that had scattered in the sudden wind settled softly to the ground. No one spoke.
-
-“Beautifully done,” he said, his tone a strange mix of reverence and regret. He stepped closer, tilting his head like a bird both curious and wary. “A ring of air. A rare thing. The first step toward something.” He hesitated, studying the space where the wind had been, then nodded faintly. “A pity. So lovely. So doomed.”
-
-I barely heard him. I was still caught in the moment before, held captive by the raw and fragile truth of what I’d just touched. It wasn’t just a moment or a trick. It was proof that I had crossed some invisible line.
-
 ### ~ ~ ~
 
 [Chapter 4](CHAPTER_04.md) | [Contents](Contents.md) | [Chapter 6](CHAPTER_06.md)

--- a/book/CHAPTER_07.md
+++ b/book/CHAPTER_07.md
@@ -15,6 +15,44 @@ I saw him that morning, before Admissions. He was hunched over a long roll of pa
 
 Herma was gone, and Kilvin stood in his place. I imagined his voice huddled behind the weight of that long table, giving counsel in that calm, rumbling tone of his. It wasn’t a bad thought. Kilvin, after all, was what people called reliable. Still, a whisper tugged at the back of my mind like a thread. Did Kilvin know what to do when the knot unraveled?
 
+But classes were to be back in session. Life at the University had, a last, continued on.  
+
+### * * *
+
+Elodin’s Naming class crackled with restless energy. Firelight from the torches danced across the stone walls, throwing shadows that writhed like living things.
+
+“Kvothe.” Elodin’s voice cut through the air, snapping my name like a bowstring. “To the center.”
+
+I hesitated, but only for a heartbeat. Every eye in the room traced my movements as I stepped forward. I stood in the circle of space Elodin had carved out for moments like this, beneath the heavy gaze of ancient stonework and brighter, watchful eyes.
+
+Elodin paced slow circles around me, his movement oddly graceful, like a bird inspecting its prey after deciding it wasn’t, in fact, dead. “Tell me,” he said quietly. “What do you see in a Name?”
+
+His tone was too calm, too deliberate, and I braced myself. “I see truth,” I replied, my voice measured, even.
+
+Elodin stopped pacing. The faintest smile curved along his lips. “Clever. And true enough. But truth is not simple. It is not clean.” He began to move again, circling me steadily. “Truth is layered, Kvothe. A fragile thread wrapped in lies, in doubt, in sharp things eager to snap under tension.”
+
+I opened my mouth to respond, but Elodin wasn’t waiting.
+
+“A Name,” he said, “is more than truth. It is balance. It is connection. It is weight. It is the thing beneath all things."
+
+He paused then, looking straight at me, eyes bright and sharp. “If you pull too hard on one thread,” he said. He gestured, and a breath of wind moved through the room. It came light as a whisper, brushing against my cheek.
+
+“Everything comes undone."
+
+The air thickened. I could feel it winding tighter around me, impossibly heavy.
+
+Elodin leaned closer, his voice soft as silk. “Say it.”
+
+The Name hovered on the edge of sense, spinning just beyond my reach. And then, like plucking a string I couldn’t see, it rang through me. Not as sound exactly, but as a trembling resonance that pulled through my chest and fingers. The wind moved, shifting in perfect harmony with the name I didn’t so much call as breathe. A melody hidden within silence, waiting to be played.
+
+For a moment, it lingered at my side, light as breath, alive with motion. Then, thin as glass, it formed a ring around my finger before dissolving.
+
+The room fell still. Papers that had scattered in the sudden wind settled softly to the ground. No one spoke.
+
+“Beautifully done,” he said, his tone a strange mix of reverence and regret. He stepped closer, tilting his head like a bird both curious and wary. “A ring of air. A rare thing. The first step toward something.” He hesitated, studying the space where the wind had been, then nodded faintly. “A pity. So lovely. So doomed.”
+
+I barely heard him. I was still caught in the moment before, held captive by the raw and fragile truth of what I’d just touched. It wasn’t just a moment or a trick. It was proof that I had crossed some invisible line.  
+
 ### * * *
 
 Denna was back in Imre.

--- a/index.html
+++ b/index.html
@@ -923,24 +923,6 @@ function display_palette() {
 <p>&ldquo;The art of listening,&rdquo; he said, &ldquo;is more than Naming. You already know this.&rdquo;  </p>
 <p>Did Elodin know I&rsquo;d had a hand in Hemme&rsquo;s downfall? Had Kilvin woven together my loose threads? But as I opened my mouth, I felt the air itself pressing against my words. I let them fall away. The answer wouldn&rsquo;t change anything.  </p>
 <p>Elodin stayed a moment longer, murmuring something that felt more like a prayer than a comment. Then he turned and walked away, leaving me there with my thoughts and the weighted silence of the burial ground.  </p>
-<h3>* * *</h3>
-<p>That night, Elodin&rsquo;s Naming class was the opposite of the graveyard. Where the grave had been still, the class crackled with restless energy. Firelight from the torches danced across the stone walls, throwing shadows that writhed like living things.</p>
-<p>&ldquo;Kvothe.&rdquo; Elodin&rsquo;s voice cut through the air, snapping my name like a bowstring. &ldquo;To the center.&rdquo;</p>
-<p>I hesitated, but only for a heartbeat. Every eye in the room traced my movements as I stepped forward. I stood in the circle of space Elodin had carved out for moments like this, beneath the heavy gaze of ancient stonework and brighter, watchful eyes.</p>
-<p>Elodin paced slow circles around me, his movement oddly graceful, like a bird inspecting its prey after deciding it wasn&rsquo;t, in fact, dead. &ldquo;Tell me,&rdquo; he said quietly. &ldquo;What do you see in a Name?&rdquo;</p>
-<p>His tone was too calm, too deliberate, and I braced myself. &ldquo;I see truth,&rdquo; I replied, my voice measured, even.</p>
-<p>Elodin stopped pacing. The faintest smile curved along his lips. &ldquo;Clever. And true enough. But truth is not simple. It is not clean.&rdquo; He began to move again, circling me steadily. &ldquo;Truth is layered, Kvothe. A fragile thread wrapped in lies, in doubt, in sharp things eager to snap under tension.&rdquo;</p>
-<p>I opened my mouth to respond, but Elodin wasn&rsquo;t waiting.</p>
-<p>&ldquo;A Name,&rdquo; he said, &ldquo;is more than truth. It is balance. It is connection. It is weight. It is the thing beneath all things."</p>
-<p>He paused then, looking straight at me, eyes bright and sharp. &ldquo;If you pull too hard on one thread,&rdquo; he said. He gestured, and a breath of wind moved through the room. It came light as a whisper, brushing against my cheek.</p>
-<p>&ldquo;Everything comes undone."</p>
-<p>The air thickened. I could feel it winding tighter around me, impossibly heavy.</p>
-<p>Elodin leaned closer, his voice soft as silk. &ldquo;Say it.&rdquo;</p>
-<p>The Name hovered on the edge of sense, spinning just beyond my reach. And then, like plucking a string I couldn&rsquo;t see, it rang through me. Not as sound exactly, but as a trembling resonance that pulled through my chest and fingers. The wind moved, shifting in perfect harmony with the name I didn&rsquo;t so much call as breathe. A melody hidden within silence, waiting to be played.</p>
-<p>For a moment, it lingered at my side, light as breath, alive with motion. Then, thin as glass, it formed a ring around my finger before dissolving.</p>
-<p>The room fell still. Papers that had scattered in the sudden wind settled softly to the ground. No one spoke.</p>
-<p>&ldquo;Beautifully done,&rdquo; he said, his tone a strange mix of reverence and regret. He stepped closer, tilting his head like a bird both curious and wary. &ldquo;A ring of air. A rare thing. The first step toward something.&rdquo; He hesitated, studying the space where the wind had been, then nodded faintly. &ldquo;A pity. So lovely. So doomed.&rdquo;</p>
-<p>I barely heard him. I was still caught in the moment before, held captive by the raw and fragile truth of what I&rsquo;d just touched. It wasn&rsquo;t just a moment or a trick. It was proof that I had crossed some invisible line.</p>
 <hr />
 <a name="CHAPTER_06"></a>
 <h1 class='chapter_title'><big>C</big>HAPTER 6.</h1>
@@ -1014,6 +996,25 @@ function display_palette() {
 <p>I heard no proclamation. No formal announcement rang across the University. Not yet, that would come later. But the evidence was everywhere. In the Hall of Stones, Herma&rsquo;s name had been carefully filed away into history. On the slab of dense, polished rock that bore the names of Chancellors past and present, Kilvin&rsquo;s name gleamed freshly carved, sharp-edged like it might cut you if pressed too hard.</p>
 <p>I saw him that morning, before Admissions. He was hunched over a long roll of parchment, thick fingers wrapped around a quill too delicate for his hand. He did not look up as I passed. I thought only of my tuition. Eighteen talents and six jots. Not the worst I&rsquo;d owed, but close enough to leave a mark. Looking back, the smallness of my worries makes me wince.</p>
 <p>Herma was gone, and Kilvin stood in his place. I imagined his voice huddled behind the weight of that long table, giving counsel in that calm, rumbling tone of his. It wasn&rsquo;t a bad thought. Kilvin, after all, was what people called reliable. Still, a whisper tugged at the back of my mind like a thread. Did Kilvin know what to do when the knot unraveled?</p>
+<p>But classes were to be back in session. Life at the University had, a last, continued on.  </p>
+<h3>* * *</h3>
+<p>Elodin&rsquo;s Naming class crackled with restless energy. Firelight from the torches danced across the stone walls, throwing shadows that writhed like living things.</p>
+<p>&ldquo;Kvothe.&rdquo; Elodin&rsquo;s voice cut through the air, snapping my name like a bowstring. &ldquo;To the center.&rdquo;</p>
+<p>I hesitated, but only for a heartbeat. Every eye in the room traced my movements as I stepped forward. I stood in the circle of space Elodin had carved out for moments like this, beneath the heavy gaze of ancient stonework and brighter, watchful eyes.</p>
+<p>Elodin paced slow circles around me, his movement oddly graceful, like a bird inspecting its prey after deciding it wasn&rsquo;t, in fact, dead. &ldquo;Tell me,&rdquo; he said quietly. &ldquo;What do you see in a Name?&rdquo;</p>
+<p>His tone was too calm, too deliberate, and I braced myself. &ldquo;I see truth,&rdquo; I replied, my voice measured, even.</p>
+<p>Elodin stopped pacing. The faintest smile curved along his lips. &ldquo;Clever. And true enough. But truth is not simple. It is not clean.&rdquo; He began to move again, circling me steadily. &ldquo;Truth is layered, Kvothe. A fragile thread wrapped in lies, in doubt, in sharp things eager to snap under tension.&rdquo;</p>
+<p>I opened my mouth to respond, but Elodin wasn&rsquo;t waiting.</p>
+<p>&ldquo;A Name,&rdquo; he said, &ldquo;is more than truth. It is balance. It is connection. It is weight. It is the thing beneath all things."</p>
+<p>He paused then, looking straight at me, eyes bright and sharp. &ldquo;If you pull too hard on one thread,&rdquo; he said. He gestured, and a breath of wind moved through the room. It came light as a whisper, brushing against my cheek.</p>
+<p>&ldquo;Everything comes undone."</p>
+<p>The air thickened. I could feel it winding tighter around me, impossibly heavy.</p>
+<p>Elodin leaned closer, his voice soft as silk. &ldquo;Say it.&rdquo;</p>
+<p>The Name hovered on the edge of sense, spinning just beyond my reach. And then, like plucking a string I couldn&rsquo;t see, it rang through me. Not as sound exactly, but as a trembling resonance that pulled through my chest and fingers. The wind moved, shifting in perfect harmony with the name I didn&rsquo;t so much call as breathe. A melody hidden within silence, waiting to be played.</p>
+<p>For a moment, it lingered at my side, light as breath, alive with motion. Then, thin as glass, it formed a ring around my finger before dissolving.</p>
+<p>The room fell still. Papers that had scattered in the sudden wind settled softly to the ground. No one spoke.</p>
+<p>&ldquo;Beautifully done,&rdquo; he said, his tone a strange mix of reverence and regret. He stepped closer, tilting his head like a bird both curious and wary. &ldquo;A ring of air. A rare thing. The first step toward something.&rdquo; He hesitated, studying the space where the wind had been, then nodded faintly. &ldquo;A pity. So lovely. So doomed.&rdquo;</p>
+<p>I barely heard him. I was still caught in the moment before, held captive by the raw and fragile truth of what I&rsquo;d just touched. It wasn&rsquo;t just a moment or a trick. It was proof that I had crossed some invisible line.  </p>
 <h3>* * *</h3>
 <p>Denna was back in Imre.</p>
 <p>I never know how these things find me, whether it&rsquo;s an overheard word or the strange way the air changes when she&rsquo;s nearby. But I knew. I felt it as surely as the first sharp note of a song.</p>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -62,15 +62,15 @@
   </url>
   <url>
     <loc>https://frypatch.github.io/The-Price-of-Remembering/book/CHAPTER_05.html</loc>
-    <lastmod>2025-12-08</lastmod>
+    <lastmod>2025-12-12</lastmod>
   </url>
   <url>
     <loc>https://frypatch.github.io/The-Price-of-Remembering/book/CHAPTER_06.html</loc>
-    <lastmod>2025-05-17</lastmod>
+    <lastmod>2025-12-12</lastmod>
   </url>
   <url>
     <loc>https://frypatch.github.io/The-Price-of-Remembering/book/CHAPTER_07.html</loc>
-    <lastmod>2025-05-17</lastmod>
+    <lastmod>2025-12-12</lastmod>
   </url>
   <url>
     <loc>https://frypatch.github.io/The-Price-of-Remembering/book/CHAPTER_08.html</loc>


### PR DESCRIPTION
The scene where Kvothe names the wind in Elodin's class should happen when classes are back in session. Also, move Kvothe's rite of passage journey to befre classes are back in session which will help to explain why he has an opertunity to "get away" and also makes it more meaningful since he is "taming the wind" before he creates his ring of wind in Elodin's class, becoming officially recognized as a Namer.